### PR TITLE
Small Analyze and Clean screen bugfixes

### DIFF
--- a/app/components/AnalyzeComponent.js
+++ b/app/components/AnalyzeComponent.js
@@ -15,7 +15,10 @@ import {
   MUSE_CHANNELS,
   EMOTIV_CHANNELS
 } from '../constants/constants';
-import { readWorkspaceCleanedEEGData, getSubjectNamesFromFiles } from '../utils/filesystem/storage';
+import {
+  readWorkspaceCleanedEEGData,
+  getSubjectNamesFromFiles
+} from '../utils/filesystem/storage';
 import SecondaryNavComponent from './SecondaryNavComponent';
 import ClickableHeadDiagramSVG from './svgs/ClickableHeadDiagramSVG';
 import JupyterPlotWidget from './JupyterPlotWidget';
@@ -52,7 +55,6 @@ interface State {
 export default class Analyze extends Component<Props, State> {
   props: Props;
   state: State;
-  handleAnalyze: () => void;
   handleChannelSelect: string => void;
   handleStepClick: (Object, Object) => void;
   handleDatasetChange: (Object, Object) => void;
@@ -70,7 +72,6 @@ export default class Analyze extends Component<Props, State> {
           ? EMOTIV_CHANNELS[0]
           : MUSE_CHANNELS[0]
     };
-    this.handleAnalyze = this.handleAnalyze.bind(this);
     this.handleChannelSelect = this.handleChannelSelect.bind(this);
     this.handleDatasetChange = this.handleDatasetChange.bind(this);
     this.handleStepClick = this.handleStepClick.bind(this);
@@ -93,13 +94,11 @@ export default class Analyze extends Component<Props, State> {
     this.setState({ activeStep: step });
   }
 
-  handleAnalyze() {
-    this.props.jupyterActions.loadERP(null);
-  }
-
   handleDatasetChange(event: Object, data: Object) {
-    this.setState({ selectedFilePaths: data.value,
-       selectedSubjects: getSubjectNamesFromFiles(data.value) });
+    this.setState({
+      selectedFilePaths: data.value,
+      selectedSubjects: getSubjectNamesFromFiles(data.value)
+    });
     this.props.jupyterActions.loadCleanedEpochs(data.value);
   }
 
@@ -109,8 +108,10 @@ export default class Analyze extends Component<Props, State> {
   }
 
   concatSubjectNames(subjects: Array<?string>) {
-    if(subjects.length < 1) { return '' }
-    return subjects.reduce((acc, curr) => `${acc}-${curr}`)
+    if (subjects.length < 1) {
+      return '';
+    }
+    return subjects.reduce((acc, curr) => `${acc}-${curr}`);
   }
 
   renderEpochLabels() {
@@ -170,7 +171,9 @@ export default class Analyze extends Component<Props, State> {
             <Grid.Column width={8}>
               <JupyterPlotWidget
                 title={this.props.title}
-                imageTitle={`${this.concatSubjectNames(this.state.selectedSubjects)}-Topoplot`}
+                imageTitle={`${this.concatSubjectNames(
+                  this.state.selectedSubjects
+                )}-Topoplot`}
                 plotMIMEBundle={this.props.topoPlot}
               />
             </Grid.Column>
@@ -202,8 +205,9 @@ export default class Analyze extends Component<Props, State> {
             <Grid.Column width={8}>
               <JupyterPlotWidget
                 title={this.props.title}
-                imageTitle={
-                  `${this.concatSubjectNames(this.state.selectedSubjects)}-${this.state.selectedChannel}-ERP`}
+                imageTitle={`${this.concatSubjectNames(
+                  this.state.selectedSubjects
+                )}-${this.state.selectedChannel}-ERP`}
                 plotMIMEBundle={this.props.erpPlot}
               />
             </Grid.Column>

--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -46,6 +46,12 @@ export const DEVICE_AVAILABILITY = {
   AVAILABLE: 'AVAILABLE'
 };
 
+// Names of variables in the jupyter kernel
+export const JUPYTER_VARIABLE_NAMES = {
+  RAW_EPOCHS: 'raw_epochs',
+  CLEAN_EPOCHS: 'clean_epochs'
+};
+
 export const SEARCH_TIMER = 3000;
 
 // NOTE: the actual marker id values of stimulus 1 and 2 are reversed

--- a/app/epics/jupyterEpics.js
+++ b/app/epics/jupyterEpics.js
@@ -375,21 +375,32 @@ const loadTopoEpic = (action$, state$) =>
         take(1)
       )
     ),
-    mergeMap(topoPlot => of(setTopoPlot(topoPlot), loadERP()))
+    mergeMap(topoPlot =>
+      of(
+        setTopoPlot(topoPlot),
+        loadERP(
+          state$.value.device.deviceType === DEVICES.EMOTIV
+            ? EMOTIV_CHANNELS[0]
+            : MUSE_CHANNELS[0]
+        )
+      )
+    )
   );
 
 const loadERPEpic = (action$, state$) =>
   action$.ofType(LOAD_ERP).pipe(
     pluck('payload'),
     map(channelName => {
-      const channels =
-        state$.value.device.deviceType === DEVICES.EMOTIV
-          ? EMOTIV_CHANNELS
-          : MUSE_CHANNELS;
-      if (channels.includes(channelName)) {
-        return channels.indexOf(channelName);
+      console.log(channelName);
+      if (MUSE_CHANNELS.includes(channelName)) {
+        return MUSE_CHANNELS.indexOf(channelName);
+      } else if (EMOTIV_CHANNELS.includes(channelName)) {
+        return EMOTIV_CHANNELS.indexOf(channelName);
       }
-      return 0;
+      console.warn(
+        'channel name supplied to loadERPEpic does not belong to either device'
+      );
+      return EMOTIV_CHANNELS[0];
     }),
     map(channelIndex =>
       state$.value.jupyter.mainChannel.next(

--- a/app/utils/jupyter/cells.js
+++ b/app/utils/jupyter/cells.js
@@ -32,8 +32,8 @@ export const loadCSV = (filePathArray: Array<string>) =>
 export const loadCleanedEpochs = (filePathArray: Array<string>) =>
   [
     `files = [${filePathArray.map(filePath => formatFilePath(filePath))}]`,
-    `epochs = concatenate_epochs([read_epochs(file) for file in files])`,
-    `conditions = OrderedDict({key: [value] for (key, value) in epochs.event_id.items()})`
+    `clean_epochs = concatenate_epochs([read_epochs(file) for file in files])`,
+    `conditions = OrderedDict({key: [value] for (key, value) in clean_epochs.event_id.items()})`
   ].join('\n');
 
 // NOTE: this command includes a ';' to prevent returning data
@@ -57,37 +57,38 @@ export const epochEvents = (
     `picks = None`,
     `reject = ${reject}`,
     'events = find_events(raw)',
-    `epochs = Epochs(raw, events=events, event_id=event_id, 
+    `raw_epochs = Epochs(raw, events=events, event_id=event_id, 
                       tmin=tmin, tmax=tmax, baseline=baseline, reject=reject, preload=True, 
                       verbose=False, picks=picks)`,
-    `conditions = OrderedDict({key: [value] for (key, value) in epochs.event_id.items()})`
+    `conditions = OrderedDict({key: [value] for (key, value) in raw_epochs.event_id.items()})`
   ].join('\n');
   return command;
 };
 
-export const requestEpochsInfo = () => `get_epochs_info(epochs)`;
+export const requestEpochsInfo = (variableName: string) =>
+  `get_epochs_info(${variableName})`;
 
 export const requestChannelInfo = () =>
-  `[ch for ch in epochs.ch_names if ch != 'Marker']`;
+  `[ch for ch in raw_epochs.ch_names if ch != 'Marker']`;
 
 export const cleanEpochsPlot = () =>
   [
     `%matplotlib`,
-    `epochs.plot(scalings='auto', n_epochs=6, title="Clean Data", events=None)`
+    `raw_epochs.plot(scalings='auto', n_epochs=6, title="Clean Data", events=None)`
   ].join('\n');
 
 export const plotTopoMap = () =>
-  [`%matplotlib inline`, `plot_topo(epochs, conditions)`].join('\n');
+  [`%matplotlib inline`, `plot_topo(clean_epochs, conditions)`].join('\n');
 
 export const plotERP = (channelIndex: number) =>
   [
     `%matplotlib inline`,
-    `X, y = plot_conditions(epochs, ch_ind=${channelIndex}, conditions=conditions, 
+    `X, y = plot_conditions(clean_epochs, ch_ind=${channelIndex}, conditions=conditions, 
     ci=97.5, n_boot=1000, title='', diff_waveform=None)`
   ].join('\n');
 
 export const saveEpochs = (workspaceDir: string, subject: string) =>
-  `epochs.save(${formatFilePath(
+  `raw_epochs.save(${formatFilePath(
     path.join(
       workspaceDir,
       'Data',

--- a/app/utils/jupyter/cells.js
+++ b/app/utils/jupyter/cells.js
@@ -69,7 +69,7 @@ export const requestEpochsInfo = (variableName: string) =>
   `get_epochs_info(${variableName})`;
 
 export const requestChannelInfo = () =>
-  `[ch for ch in raw_epochs.ch_names if ch != 'Marker']`;
+  `[ch for ch in clean_epochs.ch_names if ch != 'Marker']`;
 
 export const cleanEpochsPlot = () =>
   [


### PR DESCRIPTION
This PR separates raw and clean epochs in the jupyter kernel to prevent statefulness bugs. Also fixes a bug in which Muse ERPs weren't selectable unless an actual Muse experiment had been performed