### PR TITLE
Update Emotiv utils to use Cortex 2.0 API

### DIFF
--- a/app/epics/deviceEpics.js
+++ b/app/epics/deviceEpics.js
@@ -164,7 +164,7 @@ const connectEpic = action$ =>
     ),
     mergeMap(promise => promise.then(deviceInfo => deviceInfo)),
     mergeMap(deviceInfo => {
-      if (!isNil(deviceInfo.samplingRate)) {
+      if (!isNil(deviceInfo) && !isNil(deviceInfo.samplingRate)) {
         return of(
           setDeviceType(
             deviceInfo.name.includes('Muse') ? DEVICES.MUSE : DEVICES.EMOTIV

--- a/app/epics/deviceEpics.js
+++ b/app/epics/deviceEpics.js
@@ -1,44 +1,44 @@
-import { combineEpics } from 'redux-observable';
-import { of, from, timer } from 'rxjs';
-import { map, pluck, mergeMap, tap, filter, catchError } from 'rxjs/operators';
-import { isNil } from 'lodash';
-import { toast } from 'react-toastify';
+import { combineEpics } from "redux-observable";
+import { of, from, timer } from "rxjs";
+import { map, pluck, mergeMap, tap, filter, catchError } from "rxjs/operators";
+import { isNil } from "lodash";
+import { toast } from "react-toastify";
 import {
   CONNECT_TO_DEVICE,
   SET_DEVICE_AVAILABILITY,
   setDeviceAvailability,
   setConnectionStatus
-} from '../actions/deviceActions';
+} from "../actions/deviceActions";
 import {
   getEmotiv,
   connectToEmotiv,
   createRawEmotivObservable,
   createEmotivSignalQualityObservable,
   disconnectFromEmotiv
-} from '../utils/eeg/emotiv';
+} from "../utils/eeg/emotiv";
 import {
   getMuse,
   connectToMuse,
   createRawMuseObservable,
   createMuseSignalQualityObservable,
   disconnectFromMuse
-} from '../utils/eeg/muse';
+} from "../utils/eeg/muse";
 import {
   CONNECTION_STATUS,
   DEVICES,
   DEVICE_AVAILABILITY,
   SEARCH_TIMER
-} from '../constants/constants';
-import { EXPERIMENT_CLEANUP } from './experimentEpics';
+} from "../constants/constants";
+import { EXPERIMENT_CLEANUP } from "./experimentEpics";
 
-export const DEVICE_FOUND = 'DEVICE_FOUND';
-export const SET_DEVICE_TYPE = 'DEVICE_TYPE';
-export const SET_CONNECTION_STATUS = 'SET_CONNECTION_STATUS';
-export const SET_DEVICE_INFO = 'SET_DEVICE_INFO';
-export const SET_AVAILABLE_DEVICES = 'SET_AVAILABLE_DEVICES';
-export const SET_RAW_OBSERVABLE = 'SET_RAW_OBSERVABLE';
-export const SET_SIGNAL_OBSERVABLE = 'SET_SIGNAL_OBSERVABLE';
-export const DEVICE_CLEANUP = 'DEVICE_CLEANUP';
+export const DEVICE_FOUND = "DEVICE_FOUND";
+export const SET_DEVICE_TYPE = "DEVICE_TYPE";
+export const SET_CONNECTION_STATUS = "SET_CONNECTION_STATUS";
+export const SET_DEVICE_INFO = "SET_DEVICE_INFO";
+export const SET_AVAILABLE_DEVICES = "SET_AVAILABLE_DEVICES";
+export const SET_RAW_OBSERVABLE = "SET_RAW_OBSERVABLE";
+export const SET_SIGNAL_OBSERVABLE = "SET_SIGNAL_OBSERVABLE";
+export const DEVICE_CLEANUP = "DEVICE_CLEANUP";
 
 // -------------------------------------------------------------------------
 // Action Creators
@@ -81,7 +81,7 @@ const cleanup = () => ({ type: DEVICE_CLEANUP });
 // NOTE: Uses a Promise "then" inside b/c Observable.from leads to loss of user gesture propagation for web bluetooth
 const searchMuseEpic = action$ =>
   action$.ofType(SET_DEVICE_AVAILABILITY).pipe(
-    pluck('payload'),
+    pluck("payload"),
     filter(status => status === DEVICE_AVAILABILITY.SEARCHING),
     map(getMuse),
     mergeMap(promise =>
@@ -100,23 +100,23 @@ const searchMuseEpic = action$ =>
 
 const searchEmotivEpic = action$ =>
   action$.ofType(SET_DEVICE_AVAILABILITY).pipe(
-    pluck('payload'),
+    pluck("payload"),
     filter(status => status === DEVICE_AVAILABILITY.SEARCHING),
-    filter(() => process.platform === 'darwin' || process.platform === 'win32'),
+    filter(() => process.platform === "darwin" || process.platform === "win32"),
     map(getEmotiv),
     mergeMap(promise =>
       promise.then(
         devices => devices,
         error => {
-          if (error.message.includes('client.queryHeadsets')) {
+          if (error.message.includes("client.queryHeadsets")) {
             toast.error(
-              'Could not connect to Cortex Service. Please connect to the internet and install Cortex to use Emotiv EEG',
+              "Could not connect to Cortex Service. Please connect to the internet and install Cortex to use Emotiv EEG",
               { autoclose: 7000 }
             );
           } else {
             toast.error(`"Device Error: " ${error.toString()}`);
           }
-          console.error('searchEpic: ', error.toString());
+          console.error("searchEpic: ", error.toString());
           return [];
         }
       )
@@ -127,7 +127,7 @@ const searchEmotivEpic = action$ =>
 
 const deviceFoundEpic = (action$, state$) =>
   action$.ofType(DEVICE_FOUND).pipe(
-    pluck('payload'),
+    pluck("payload"),
     map(foundDevices =>
       foundDevices.reduce((acc, curr) => {
         if (acc.find(device => device.id === curr.id)) {
@@ -146,7 +146,7 @@ const deviceFoundEpic = (action$, state$) =>
 
 const searchTimerEpic = (action$, state$) =>
   action$.ofType(SET_DEVICE_AVAILABILITY).pipe(
-    pluck('payload'),
+    pluck("payload"),
     filter(status => status === DEVICE_AVAILABILITY.SEARCHING),
     mergeMap(() => timer(SEARCH_TIMER)),
     filter(
@@ -158,7 +158,7 @@ const searchTimerEpic = (action$, state$) =>
 
 const connectEpic = action$ =>
   action$.ofType(CONNECT_TO_DEVICE).pipe(
-    pluck('payload'),
+    pluck("payload"),
     map(device =>
       isNil(device.name) ? connectToEmotiv(device) : connectToMuse(device)
     ),
@@ -167,7 +167,7 @@ const connectEpic = action$ =>
       if (!isNil(deviceInfo) && !isNil(deviceInfo.samplingRate)) {
         return of(
           setDeviceType(
-            deviceInfo.name.includes('Muse') ? DEVICES.MUSE : DEVICES.EMOTIV
+            deviceInfo.name.includes("Muse") ? DEVICES.MUSE : DEVICES.EMOTIV
           ),
           setDeviceInfo(deviceInfo),
           setConnectionStatus(CONNECTION_STATUS.CONNECTED)
@@ -195,7 +195,7 @@ const setRawObservableEpic = (action$, state$) =>
 
 const setSignalQualityObservableEpic = (action$, state$) =>
   action$.ofType(SET_RAW_OBSERVABLE).pipe(
-    pluck('payload'),
+    pluck("payload"),
     map(rawObservable => {
       if (state$.value.device.deviceType === DEVICES.EMOTIV) {
         return createEmotivSignalQualityObservable(

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "BrainWaves",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/utils/eeg/cortex.js
+++ b/app/utils/eeg/cortex.js
@@ -13,15 +13,15 @@
  * event (mot, eeg, etc) is emitted as its own event that you can listen for
  * whether or not there are any active subscriptions at the time.
  *
- * The API methods are defined by using Cortex's inspectApi call. We mostly
+ * The API methods are defined by using Cortex"s inspectApi call. We mostly
  * just pass information back and forth without doing much with it, with the
  * exception of the login/auth flow, which we expose as the init() method.
  */
 
-const WebSocket = require('ws');
-const EventEmitter = require('events');
+const WebSocket = require("ws");
+const EventEmitter = require("events");
 
-const CORTEX_URL = 'wss://localhost:6868';
+const CORTEX_URL = "wss://localhost:6868";
 
 const safeParse = msg => {
   try {
@@ -32,7 +32,7 @@ const safeParse = msg => {
 };
 
 if (global.process) {
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 }
 
 class JSONRPCError extends Error {
@@ -55,9 +55,9 @@ class Cortex extends EventEmitter {
     this.msgId = 0;
     this.requests = {};
     this.streams = {};
-    this.ws.addEventListener('message', this._onmsg.bind(this));
-    this.ws.addEventListener('close', () => {
-      this._log('ws: Socket closed');
+    this.ws.addEventListener("message", this._onmsg.bind(this));
+    this.ws.addEventListener("close", () => {
+      this._log("ws: Socket closed");
     });
     this.verbose = options.verbose !== null ? options.verbose : 1;
     this.handleError = error => {
@@ -65,11 +65,11 @@ class Cortex extends EventEmitter {
     };
 
     this.ready = new Promise(
-      resolve => this.ws.addEventListener('open', resolve),
+      resolve => this.ws.addEventListener("open", resolve),
       this.handleError
     )
-      .then(() => this._log('ws: Socket opened'))
-      .then(() => this.call('inspectApi'))
+      .then(() => this._log("ws: Socket opened"))
+      .then(() => this.call("inspectApi"))
       .then(methods => {
         methods.forEach(m => {
           this.defineMethod(m.methodName, m.params);
@@ -80,54 +80,54 @@ class Cortex extends EventEmitter {
   }
   _onmsg(msg) {
     const data = safeParse(msg.data);
-    if (!data) return this._warn('unparseable message', msg);
+    if (!data) return this._warn("unparseable message", msg);
 
-    this._debug('ws: <-', msg.data);
+    this._debug("ws: <-", msg.data);
 
-    if ('id' in data) {
+    if ("id" in data) {
       const id = data.id;
       this._log(
         `[${id}] <-`,
-        data.result ? 'success' : `error (${data.error.message})`
+        data.result ? "success" : `error (${data.error.message})`
       );
       if (this.requests[id]) {
         this.requests[id](data.error, data.result);
       } else {
-        this._warn('rpc: Got response for unknown id', id);
+        this._warn("rpc: Got response for unknown id", id);
       }
-    } else if ('sid' in data) {
+    } else if ("sid" in data) {
       const dataKeys = Object.keys(data).filter(
-        k => k !== 'sid' && k !== 'time' && Array.isArray(data[k])
+        k => k !== "sid" && k !== "time" && Array.isArray(data[k])
       );
       dataKeys.forEach(
         k =>
-          this.emit(k, data) || this._warn('no listeners for stream event', k)
+          this.emit(k, data) || this._warn("no listeners for stream event", k)
       );
     } else {
-      this._log('rpc: Unrecognised data', data);
+      this._log("rpc: Unrecognised data", data);
     }
   }
   _warn(...msg) {
-    if (this.verbose > 0) console.warn('[Cortex WARN]', ...msg);
+    if (this.verbose > 0) console.warn("[Cortex WARN]", ...msg);
   }
   _log(...msg) {
-    if (this.verbose > 1) console.log('[Cortex LOG]', ...msg);
+    if (this.verbose > 1) console.log("[Cortex LOG]", ...msg);
   }
   _debug(...msg) {
-    if (this.verbose > 2) console.debug('[Cortex DEBUG]', ...msg);
+    if (this.verbose > 2) console.debug("[Cortex DEBUG]", ...msg);
   }
   init({ clientId, clientSecret, license, debit } = {}) {
     const token = this.getUserLogin()
       .then(users => {
         if (users.length === 0) {
-          return Promise.Reject(new Error('No logged in user'));
+          return Promise.Reject(new Error("No logged in user"));
         }
         return this.requestAccess({ clientId, clientSecret });
       })
       .then(({ accessGranted }) => {
         if (!accessGranted) {
           return Promise.Reject(
-            new Error('Please approve this application in the EMOTIV app')
+            new Error("Please approve this application in the EMOTIV app")
           );
         }
         return this.authorize({
@@ -136,8 +136,8 @@ class Cortex extends EventEmitter {
           license,
           debit
         }).then(({ cortexToken }) => {
-          this._log('init: Got auth token');
-          this._debug('init: Auth token', cortexToken);
+          this._log("init: Got auth token");
+          this._debug("init: Auth token", cortexToken);
           this.cortexToken = cortexToken;
           return cortexToken;
         });
@@ -148,29 +148,29 @@ class Cortex extends EventEmitter {
   close() {
     return new Promise(resolve => {
       this.ws.close();
-      this.ws.once('close', resolve);
+      this.ws.once("close", resolve);
     });
   }
   call(method, params = {}) {
     const id = this.msgId++;
-    const msg = JSON.stringify({ jsonrpc: '2.0', method, params, id });
+    const msg = JSON.stringify({ jsonrpc: "2.0", method, params, id });
     this.ws.send(msg);
     this._log(`[${id}] -> ${method}`);
 
-    this._debug('ws: ->', msg);
+    this._debug("ws: ->", msg);
     return new Promise((resolve, reject) => {
       this.requests[id] = (err, data) => {
         delete this.requests[id];
-        this._debug('rpc: err', err, 'data', data);
+        this._debug("rpc: err", err, "data", data);
         if (err) return reject(new JSONRPCError(err));
         if (data) return resolve(data);
-        return reject(new Error('Invalid JSON-RPC response'));
+        return reject(new Error("Invalid JSON-RPC response"));
       };
     });
   }
   defineMethod(methodName, paramDefs = []) {
     if (this[methodName]) return;
-    const needsAuth = paramDefs.some(p => p.name === 'cortexToken');
+    const needsAuth = paramDefs.some(p => p.name === "cortexToken");
     const requiredParams = paramDefs.filter(p => p.required).map(p => p.name);
 
     this[methodName] = (params = {}) => {
@@ -182,7 +182,7 @@ class Cortex extends EventEmitter {
         return this.handleError(
           new Error(
             `Missing required params for ${methodName}: ${missingParams.join(
-              ', '
+              ", "
             )}`
           )
         );

--- a/app/utils/eeg/emotiv.js
+++ b/app/utils/eeg/emotiv.js
@@ -8,13 +8,7 @@ import { map, withLatestFrom, share } from 'rxjs/operators';
 import { addInfo, epoch, bandpassFilter } from '@neurosity/pipes';
 import { toast } from 'react-toastify';
 import { parseEmotivSignalQuality } from './pipes';
-import {
-  USERNAME,
-  PASSWORD,
-  CLIENT_ID,
-  CLIENT_SECRET,
-  LICENSE_ID
-} from '../../../keys';
+import { CLIENT_ID, CLIENT_SECRET, LICENSE_ID } from '../../../keys';
 import { EMOTIV_CHANNELS, PLOTTING_INTERVAL } from '../../constants/constants';
 import Cortex from './cortex';
 
@@ -34,8 +28,6 @@ export const connectToEmotiv = device =>
     .then(() =>
       client.init({
         // These values need to be filled with personal Emotiv credentials
-        username: USERNAME,
-        password: PASSWORD,
         client_id: CLIENT_ID,
         client_secret: CLIENT_SECRET,
         license: LICENSE_ID,
@@ -47,11 +39,19 @@ export const connectToEmotiv = device =>
       return err;
     })
     .then(() =>
-      client.createSession({
+      client.controlDevice({ command: 'connect', headset: device.id })
+    )
+    .catch(err => {
+      toast.error(`Emotiv connection failed. ${err}`);
+      return err;
+    })
+    .then(({ message }) => {
+      console.log(message);
+      return client.createSession({
         status: 'active',
         headset: device.id
-      })
-    )
+      });
+    })
     .catch(err => {
       toast.error(`Session creation failed. ${err} `);
       return err;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "BrainWaves",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2103,12 +2103,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
-    },
-    "ast-metadata-inferer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1.tgz",
-      "integrity": "sha512-hc9w8Qrgg9Lf9iFcZVhNjUnhrd2BBpTlyCnegPVvCe6O0yMrF57a6Cmh7k+xUsfUOMh9wajOL5AsGOBNEyTCcw==",
       "dev": true
     },
     "ast-types": {
@@ -7753,6 +7747,20 @@
             "universalify": "^0.1.0"
           }
         },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -7784,6 +7792,25 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
+        "node-gyp": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.5.tgz",
+          "integrity": "sha512-WABl9s4/mqQdZneZHVWVG4TVr6QQJZUC6PAx47ITSk9lreZ1n+7Z9mMAIbA3vnO4J9W20P7LhCxtzfWsAD/KDw==",
+          "dev": true,
+          "requires": {
+            "env-paths": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "request": "^2.87.0",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^4.4.12",
+            "which": "1"
+          }
+        },
         "p-limit": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
@@ -7812,6 +7839,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "string-width": {
@@ -12352,59 +12385,17 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.0.tgz",
-      "integrity": "sha512-yss1ZbupTpRfe86dpM1abxnnSfxa6eIRn3laqBPIgRYy87qgYtX6xinSOeybjYo/4AVzdTTWK5Kr06A6AllxJg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
-        "eslint-plugin-compat": "^3.3.0",
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "browserslist": {
-          "version": "4.7.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-          "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001004",
-            "electron-to-chromium": "^1.3.295",
-            "node-releases": "^1.1.38"
-          }
-        },
-        "eslint-plugin-compat": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.3.0.tgz",
-          "integrity": "sha512-QCgYy3pZ+zH10dkBJus1xER0359h1UhJjufhQRqp9Owm6BEoLZeSqxf2zINwL1OGao9Yc96xPYIW3nQj5HUryg==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.4.5",
-            "ast-metadata-inferer": "^0.1.1",
-            "browserslist": "^4.6.3",
-            "caniuse-db": "^1.0.30000977",
-            "lodash.memoize": "4.1.2",
-            "mdn-browser-compat-data": "^0.0.84",
-            "semver": "^6.1.2"
-          }
-        },
-        "mdn-browser-compat-data": {
-          "version": "0.0.84",
-          "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.84.tgz",
-          "integrity": "sha512-fAznuGNaQMQiWLVf+gyp33FaABTglYWqMT7JqvH+4RZn2UQPD12gbMqxwP9m0lj8AAbNpu5/kD6n4Ox1SOffpw==",
-          "dev": true,
-          "requires": {
-            "extend": "3.0.2"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -12412,9 +12403,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.6.4",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
-          "integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
+          "integrity": "sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17143,28 +17134,34 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.5.tgz",
-      "integrity": "sha512-WABl9s4/mqQdZneZHVWVG4TVr6QQJZUC6PAx47ITSk9lreZ1n+7Z9mMAIbA3vnO4J9W20P7LhCxtzfWsAD/KDw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-6.0.1.tgz",
+      "integrity": "sha512-udHG4hGe3Ji97AYJbJhaRwuSOuQO7KHnE4ZPH3Sox3tjRZ+bkBsDvfZ7eYA1qwD8eLWr//193x806ss3HFTPRw==",
       "dev": true,
       "requires": {
-        "env-paths": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "npmlog": "^4.1.2",
+        "request": "^2.88.0",
+        "rimraf": "^2.6.3",
+        "semver": "^5.7.1",
         "tar": "^4.4.12",
-        "which": "1"
+        "which": "^1.3.1"
       },
       "dependencies": {
+        "env-paths": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+          "dev": true
+        },
         "glob": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
-          "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -17175,11 +17172,15 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "jest": "^23.0.0",
     "lint-staged": "^7.1.2",
     "minimist": "^1.2.0",
+    "node-gyp": "^6.0.1",
     "node-sass": "^4.9.0",
     "npm-logical-tree": "^1.2.1",
     "patch-package": "^5.1.1",


### PR DESCRIPTION
This deprecates https://github.com/makebrainwaves/BrainWaves/pull/94 and allows the app to connect to Emotiv's via the new version of the Cortex app provided by Emotiv.

This is almost good to go, but merging of this should await a new license from Emotiv. The current license we have is expired, which prevents me from testing the raw EEG features. However, there doesn't appear to be any reason that they would have changed given the updates were primarily around authorization and device connectivity.