### PR TITLE
Fix six small bugs and footguns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ dist
 .idea
 keys.js
 src/renderer/utils/webworker/src
+
+# Generated Pyodide runtime payload (downloaded by install scripts, not source)
+src/renderer/utils/pyodide/src
+
+# Python bytecode cache
+__pycache__/
+*.pyc

--- a/.llms/learnings.md
+++ b/.llms/learnings.md
@@ -82,6 +82,12 @@ In dev: use `/@fs<absPath>` (Vite's `/@fs/` serving). In prod: use `file://<absP
 
 Any hook function (e.g. `initResponseHandlers` in `src/renderer/utils/labjs/functions.ts`) that needs the component ID must use `this.id`, not `this.options.id`. Using `this.options.id` will always be `undefined` for loop-cloned components, causing silent early returns and broken behavior (e.g. keydown handlers never installed).
 
+## Behavior data: booleans become strings after the CSV round-trip
+
+Experiments emit `this.data.correct_response` as a real boolean (`true`/`false`) and `response_given` as `'yes'`/`'no'` (see `src/renderer/utils/labjs/functions.ts`). But all consumers in `src/renderer/utils/behavior/compute.js` read data **after** it's been written to CSV and re-parsed, so every value is a **string**. That's why existing code gates on `row.correct_response === 'true'` and `row.response_given === 'yes'`, and parses numbers with `parseFloat`.
+
+Trap: a new metric written naively (`row.correct_response === true`, or arithmetic on an unparsed string) will silently return `false`/`0`/`NaN` for post-CSV data — and may *work* on pre-CSV in-memory data, so it passes a quick test and fails in production. Always compare against the string `'true'`/`'yes'` and `parseFloat` before doing math.
+
 ## Pre-existing TypeScript errors (do not treat as regressions)
 
 - `src/renderer/epics/experimentEpics.ts` (lines 170, 205) — RxJS operator type mismatch

--- a/src/renderer/actions/deviceActions.ts
+++ b/src/renderer/actions/deviceActions.ts
@@ -9,8 +9,8 @@ import { Device, DeviceInfo } from '../constants/interfaces';
 export const DeviceActions = {
   // TODO: write type for devices
   ConnectToDevice: createAction<Device>('CONNECT_TO_DEVICE'),
-  DisconnectFromDevice: createAction<void, 'EXPERIMENT_CLEANUP'>(
-    'EXPERIMENT_CLEANUP'
+  DisconnectFromDevice: createAction<void, 'DISCONNECT_FROM_DEVICE'>(
+    'DISCONNECT_FROM_DEVICE'
   ),
   SetConnectionStatus: createAction<CONNECTION_STATUS, 'SET_CONNECTION_STATUS'>(
     'SET_CONNECTION_STATUS'

--- a/src/renderer/actions/experimentActions.ts
+++ b/src/renderer/actions/experimentActions.ts
@@ -13,7 +13,6 @@ import { ExperimentStateType } from '../reducers/experimentReducer';
 
 export const ExperimentActions = {
   Start: createAction('START'),
-  Pause: createAction('PAUSE'),
   Stop: createAction<{ data: string }, 'STOP'>('STOP'),
   SetType: createAction<EXPERIMENTS, 'SET_TYPE'>('SET_TYPE'),
   SetExperimentObject: createAction<ExperimentObject, 'SET_EXPERIMENT_OBJECT'>(

--- a/src/renderer/constants/interfaces.ts
+++ b/src/renderer/constants/interfaces.ts
@@ -24,7 +24,6 @@ export type ExperimentParameters = {
   description?: ExperimentDescription;
   intro: string;
   iti: number;
-  jitter: number;
   nbPracticeTrials?: number;
   nbTrials: number;
   presentationTime?: number;

--- a/src/renderer/epics/experimentEpics.ts
+++ b/src/renderer/epics/experimentEpics.ts
@@ -9,7 +9,11 @@ import {
   tap,
 } from 'rxjs/operators';
 import { isActionOf } from '../utils/redux';
-import { ExperimentActions, ExperimentActionType } from '../actions';
+import {
+  DeviceActions,
+  ExperimentActions,
+  ExperimentActionType,
+} from '../actions';
 import { RouterActions } from '../actions/routerActions';
 import {
   DEVICES,
@@ -214,6 +218,18 @@ const navigationCleanupEpic: Epic<any, ExperimentActionType, RootState> = (
     map(() => ExperimentActions.ExperimentCleanup())
   );
 
+// Disconnecting a device tears down the experiment too: this triggers the BLE
+// disconnect (deviceCleanupEpic) and resets experiment + pyodide state.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const disconnectFromDeviceEpic: Epic<any, ExperimentActionType, RootState> = (
+  // DeviceActions input action is outside this slice's action union
+  action$
+) =>
+  action$.pipe(
+    filter(isActionOf(DeviceActions.DisconnectFromDevice)),
+    map(() => ExperimentActions.ExperimentCleanup())
+  );
+
 export default combineEpics(
   createNewWorkspaceEpic,
   startEpic,
@@ -221,5 +237,6 @@ export default combineEpics(
   updateSessionEpic,
   autoSaveEpic,
   saveWorkspaceEpic,
-  navigationCleanupEpic
+  navigationCleanupEpic,
+  disconnectFromDeviceEpic
 );

--- a/src/renderer/experiments/faces_houses/params.ts
+++ b/src/renderer/experiments/faces_houses/params.ts
@@ -39,7 +39,6 @@ export const params = {
   iti: 500,
   presentationTime: 1000,
   selfPaced: true,
-  jitter: 200,
   sampleType: 'with-replacement',
   intro: `You will view a series of faces and houses. Press 1 when a face appears
   and 9 for a house. Press the the space bar on your keyboard to start doing the

--- a/src/renderer/experiments/multitasking/params.ts
+++ b/src/renderer/experiments/multitasking/params.ts
@@ -4,7 +4,6 @@ export const params = {
   trialDuration: 1000,
   nbTrials: 150,
   iti: 1000,
-  jitter: 200,
   sampleType: 'with-replacement',
   intro: `In this task you will learn about multitasking difficulties using a
   task mixing and switching paradigm. You will go through several instruction

--- a/src/renderer/experiments/search/params.ts
+++ b/src/renderer/experiments/search/params.ts
@@ -4,7 +4,6 @@ export const params = {
   trialDuration: 1000,
   nbTrials: 150,
   iti: 500,
-  jitter: 200,
   sampleType: 'with-replacement',
   intro: `You know how difficult it is to find your keys in a messy room. We
   want to know how good you are in quickly finding your keys. Instead of keys,

--- a/src/renderer/experiments/stroop/params.ts
+++ b/src/renderer/experiments/stroop/params.ts
@@ -10,7 +10,6 @@ export const params = {
   trialDuration: 1000,
   nbTrials: 150,
   iti: 500,
-  jitter: 200,
   sampleType: 'with-replacement',
   intro: `In this experiment, your task will be to identify the color of the
   word shown on the screen. The word itself is immaterial - you can safely

--- a/src/renderer/reducers/pyodideReducer.ts
+++ b/src/renderer/reducers/pyodideReducer.ts
@@ -83,7 +83,9 @@ export default createReducer(initialState, (builder) =>
       return {
         ...state,
         epochsInfo: [],
+        channelInfo: [],
         psdPlot: null,
+        topoPlot: null,
         erpPlot: null,
       };
     })

--- a/src/renderer/utils/labjs/protocols/custom.ts
+++ b/src/renderer/utils/labjs/protocols/custom.ts
@@ -54,7 +54,6 @@ export const buildCustomTimeline = () => ({
     iti: 500,
     presentationTime: 1000,
     selfPaced: true,
-    jitter: 200,
     sampleType: 'with-replacement',
     intro: '',
     taskHelp: '',

--- a/src/renderer/utils/webworker/index.ts
+++ b/src/renderer/utils/webworker/index.ts
@@ -186,5 +186,5 @@ export const saveEpochs = (
         'EEG',
         `${subject}-cleaned-epo.fif`
       )
-    )}`,
+    )})`,
   });


### PR DESCRIPTION
- saveEpochs: add missing closing paren so raw_epochs.save no longer raises a Python syntax error and silently fails
- Remove dead Pause/'PAUSE' experiment action (zero references)
- Remove dead `jitter` param (declared/assigned 200, never read)
- pyodideReducer: ExperimentCleanup now also resets topoPlot and channelInfo (were left stale after cleanup)
- DisconnectFromDevice: give it its own 'DISCONNECT_FROM_DEVICE' type instead of colliding with 'EXPERIMENT_CLEANUP'; an epic in experimentEpics translates it to ExperimentCleanup (behavior preserved)
- Document the post-CSV string-coercion trap in .llms/learnings.md
- .gitignore: exclude generated pyodide/src runtime payload and __pycache__