### PR TITLE
fix(macos): ad-hoc sign the app bundle, document the quarantine step

### DIFF
--- a/.llms/learnings.md
+++ b/.llms/learnings.md
@@ -194,6 +194,28 @@ builds`. Symptom was a Pyodide error, cause was the release pipeline. Set to
 looks wrong, check asset `created_at` against the tag date before debugging the app:
 `gh api repos/OWNER/REPO/releases/tags/TAG --jq '.assets[] | "\(.name) \(.created_at)"'`
 
+## macOS "BrainWaves is damaged" = unsigned bundle + quarantine, not a build bug
+
+Release CI has no Apple signing cert, so the macOS job logs `skipped macOS
+application code signing reason=cannot find valid "Developer ID Application"
+identity … 0 identities found` and ships an unsigned `.app`. Downloaded via a
+browser it carries `com.apple.quarantine`, and Gatekeeper's message for a
+quarantined bundle that is neither Developer-ID-signed nor notarized is
+**"is damaged and can't be opened"** — misleading, since nothing is corrupt.
+Right-click → Open does not bypass it; only `xattr -dr com.apple.quarantine`
+does (documented in README "Installing"). Signed-but-not-notarized would instead
+say "developer cannot be verified", so the wording tells you which state you're in.
+
+Separately, arm64 enforces code signing at *exec* time, so an unsigned bundle can
+die on launch even after quarantine is stripped. `afterPack.mjs` therefore ad-hoc
+signs (`codesign --force --deep --sign -`) and verifies the whole `.app` after the
+liblsl rewrite — that ordering matters, since `app.asar.unpacked` is inside the
+seal. Ad-hoc signing does *not* appease Gatekeeper; only Developer ID + notarization
+removes the xattr step. When a real identity is added, electron-builder's signing
+step runs after this hook and supersedes the ad-hoc signature.
+
+Check the CI log before debugging the app: `gh run view <id> --log | grep -i sign`.
+
 ## Pyodide `indexURL` is what stops the fallback to `calculateDirname()`
 
 If `loadPyodide()` is called without `indexURL`, pyodide derives one by throwing an

--- a/README.md
+++ b/README.md
@@ -18,7 +18,33 @@
   <img src="app_home.png" width="600">
 </p>
 
+## Installing
+
+Download the installer for your platform from the
+[latest release](https://github.com/makebrainwaves/BrainWaves/releases/latest).
+
+### macOS — "BrainWaves is damaged and can't be opened"
+
+BrainWaves is not yet signed with an Apple Developer ID, so macOS refuses to open
+it after download. The app is fine; macOS just can't verify who built it. Remove
+the download quarantine flag to open it:
+
+```bash
+xattr -dr com.apple.quarantine ~/Downloads/BrainWaves-*-arm64.dmg
+```
+
+Then open the `.dmg`, drag BrainWaves to Applications, and:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/BrainWaves.app
+```
+
+Right-click → Open does **not** work for this dialog — the quarantine flag has to
+go. This step disappears once the project is signed and notarized.
+
 ## Prerequisites
+
+The rest of this README is for developers building from source.
 
 - **Node.js** >= 18
 - **npm** >= 9

--- a/internals/scripts/afterPack.mjs
+++ b/internals/scripts/afterPack.mjs
@@ -1,5 +1,6 @@
 /**
- * electron-builder afterPack hook — make the bundled macOS liblsl self-contained.
+ * electron-builder afterPack hook — make the bundled macOS liblsl self-contained,
+ * then re-seal the app bundle with an ad-hoc signature.
  *
  * Why this exists
  * ---------------
@@ -27,6 +28,18 @@
  * Homebrew symlink and the packaged dylib has no external paths to rewrite —
  * confirm with `otool -L` showing only @loader_path/@rpath + /usr/lib, then
  * delete this hook and its `build.afterPack` wiring in package.json.
+ *
+ * The ad-hoc re-seal
+ * ------------------
+ * Release CI has no "Developer ID Application" identity, so electron-builder
+ * logs `skipped macOS application code signing` and ships the bundle as-is —
+ * with a seal that packaging (and the liblsl rewrite above) already invalidated.
+ * arm64 enforces code signing at exec time, so such a bundle can be killed on
+ * launch even after the user strips quarantine. Ad-hoc signing fixes *that*; it
+ * does NOT satisfy Gatekeeper, which still reports "damaged" for any quarantined
+ * bundle that isn't Developer-ID-signed and notarized (see README, macOS
+ * install). Once a real identity exists, electron-builder's own signing step
+ * runs after this hook and supersedes the ad-hoc signature — no change needed.
  */
 import { execFileSync } from 'child_process';
 import { copyFileSync, chmodSync, existsSync, realpathSync } from 'fs';
@@ -84,9 +97,12 @@ function makeSelfContained(dylib, destDir, visited = new Set()) {
 export default async function afterPack(context) {
   if (context.electronPlatformName !== 'darwin') return;
 
-  const prebuild = join(
+  const app = join(
     context.appOutDir,
-    `${context.packager.appInfo.productFilename}.app`,
+    `${context.packager.appInfo.productFilename}.app`
+  );
+  const prebuild = join(
+    app,
     'Contents/Resources/app.asar.unpacked/node_modules/node-labstreaminglayer/prebuild'
   );
   const liblsl = join(prebuild, 'liblsl.dylib');
@@ -100,4 +116,10 @@ export default async function afterPack(context) {
   console.log('[afterPack] Making liblsl.dylib self-contained:', liblsl);
   makeSelfContained(liblsl, prebuild);
   console.log('[afterPack] liblsl external deps bundled + re-signed.');
+
+  console.log('[afterPack] Ad-hoc signing bundle:', app);
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', app]);
+  // Fail the build rather than ship a bundle arm64 will refuse to exec.
+  execFileSync('codesign', ['--verify', '--deep', '--strict', app]);
+  console.log('[afterPack] Bundle ad-hoc signed and verified.');
 }


### PR DESCRIPTION
## Problem

Downloading `BrainWaves-1.0.0-arm64.dmg` from the releases page and opening it on an M1 Mac gives **"BrainWaves is damaged and can't be opened. You should move it to the Trash."**

Nothing is corrupt. From the v1.0.0 release run (`31503905780`, macos job):

```
• skipped macOS application code signing  reason=cannot find valid "Developer ID Application"
  identity or custom non-Apple code signing certificate … allIdentities= 0 identities found
```

There is no signing cert in CI, so the `.app` ships unsigned. The browser stamps the download with `com.apple.quarantine`, and "damaged" is simply Gatekeeper's wording for a quarantined bundle that is neither Developer-ID-signed nor notarized. (Signed-but-not-notarized would say "developer cannot be verified" instead — the wording tells you which state you're in.) Right-click → Open does **not** bypass this one.

Separately, arm64 enforces code signing at *exec* time, so an unsigned bundle can be killed on launch even after a user strips quarantine.

## Changes

- **`internals/scripts/afterPack.mjs`** — ad-hoc sign (`codesign --force --deep --sign -`) and verify the whole `.app`, after the liblsl rewrite since `app.asar.unpacked` is inside the seal. Fixes the exec-time kill; does **not** appease Gatekeeper. When a real identity is added, electron-builder's signing step runs after this hook and supersedes the ad-hoc signature — no change needed then.
- **`README.md`** — an "Installing" section pointing at the latest release with the exact `xattr -dr com.apple.quarantine` commands.
- **`.llms/learnings.md`** — so this isn't rediagnosed as a Pyodide regression next time.

## Test plan

- [x] macOS release job goes green — `codesign --verify --deep --strict` is strict, so if a nested Electron helper trips it the build fails loudly rather than shipping silently. May need `--strict` dropped on first run.
- [x] `[afterPack] Bundle ad-hoc signed and verified.` appears in the macos job log.
- [x] On the next tag's `.dmg`: `codesign -dv --verbose=4` shows an ad-hoc signature, and after `xattr -dr com.apple.quarantine` the app launches.

Not verified locally — no `node` on the machine this was authored from, so the hook is unexecuted. Existing v1.0.0 assets stay unsigned; this only affects the next tag.

## Follow-up

Developer ID + notarization is the only thing that removes the `xattr` step for users. ~20 lines of workflow plus `mac.hardenedRuntime`/entitlements, gated on four secrets, and a $99/yr Apple Developer membership. Deferred until distribution is closer.