### PR TITLE
chore: remove gstack vendored references from project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,3 @@
 @.llms/CLAUDE.md
 @.llms/learnings.md
 
-## Skill routing
-
-When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
-
-Key routing rules:
-- Product ideas/brainstorming → invoke /office-hours
-- Strategy/scope → invoke /plan-ceo-review
-- Architecture → invoke /plan-eng-review
-- Design system/plan review → invoke /design-consultation or /plan-design-review
-- Full review pipeline → invoke /autoplan
-- Bugs/errors → invoke /investigate
-- QA/testing site behavior → invoke /qa or /qa-only
-- Code review/diff check → invoke /review
-- Visual polish → invoke /design-review
-- Ship/deploy/PR → invoke /ship or /land-and-deploy
-- Save progress → invoke /context-save
-- Resume context → invoke /context-restore
-- Author a backlog-ready spec/issue → invoke /spec

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,6 +1,6 @@
 # TODOS
 
-Deferred and in-flight work. Keep this current — when something ships, delete it or move it under "Done recently". See `ROADMAP.md` for the strategic frame and `.gstack/` CEO plan (2026-07-02 summer-revival-reframe) for the reasoning behind the priorities below.
+Deferred and in-flight work. Keep this current — when something ships, delete it or move it under "Done recently". See `ROADMAP.md` for the strategic frame and CEO plan (2026-07-02 summer-revival-reframe) for the reasoning behind the priorities below.
 
 ## Now (Summer 2026 critical path)
 


### PR DESCRIPTION
- Remove gstack skill routing from CLAUDE.md
- Update TODOS.md reference from .gstack/ to CEO plan