### PR TITLE
fix: authorize built-in stimuli, render Analyze plots, load multi-tasking images

### DIFF
--- a/src/main/__tests__/stimulusFileAccess.test.ts
+++ b/src/main/__tests__/stimulusFileAccess.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { StimulusFileAccess } from '../stimulusFileAccess';
+import {
+  StimulusFileAccess,
+  authorizeBuiltInStimulusDirectories,
+} from '../stimulusFileAccess';
 import { toStimulusFileUrl } from '../../shared/stimulusUrl';
 
 describe('StimulusFileAccess', () => {
@@ -51,6 +54,100 @@ describe('StimulusFileAccess', () => {
     fs.writeFileSync(file, 'image');
     expect(reloaded.resolveUrl(toStimulusFileUrl(file))).toBe(
       fs.realpathSync(file)
+    );
+  });
+
+  it('resolves files under an implicit directory', () => {
+    const implicit = path.join(root, 'built-in', 'stimuli');
+    fs.mkdirSync(implicit, { recursive: true });
+    access.addImplicitDirectory(implicit);
+
+    const file = path.join(implicit, 'builtin.png');
+    fs.writeFileSync(file, 'image');
+    expect(access.resolveUrl(toStimulusFileUrl(file))).toBe(
+      fs.realpathSync(file)
+    );
+  });
+
+  it('does not persist implicit directories', () => {
+    const implicit = path.join(root, 'built-in', 'stimuli');
+    fs.mkdirSync(implicit, { recursive: true });
+    access.addImplicitDirectory(implicit);
+
+    const reloaded = new StimulusFileAccess(path.join(root, 'authorized.json'));
+    const file = path.join(implicit, 'builtin.png');
+    fs.writeFileSync(file, 'image');
+    expect(() => reloaded.resolveUrl(toStimulusFileUrl(file))).toThrow(
+      'StimulusFileAccess.resolveUrl: file is not in an authorized directory'
+    );
+  });
+});
+
+describe('authorizeBuiltInStimulusDirectories', () => {
+  let root: string;
+  let access: StimulusFileAccess;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'bw-builtin-'));
+    access = new StimulusFileAccess(path.join(root, 'authorized.json'));
+
+    // Simulate <resource>/experiments/<experiment>/stimuli layout.
+    fs.mkdirSync(path.join(root, 'experiments', 'faces_houses', 'stimuli'), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(root, 'experiments', 'multitasking', 'stimuli'), {
+      recursive: true,
+    });
+    // A directory without stimuli should be ignored.
+    fs.mkdirSync(path.join(root, 'experiments', 'custom'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('authorizes every experiments/<experiment>/stimuli directory', () => {
+    authorizeBuiltInStimulusDirectories(access, root);
+
+    const face = path.join(
+      root,
+      'experiments',
+      'faces_houses',
+      'stimuli',
+      'face.jpg'
+    );
+    const shape = path.join(
+      root,
+      'experiments',
+      'multitasking',
+      'stimuli',
+      'shape.png'
+    );
+    fs.writeFileSync(face, 'image');
+    fs.writeFileSync(shape, 'image');
+
+    expect(access.resolveUrl(toStimulusFileUrl(face))).toBe(
+      fs.realpathSync(face)
+    );
+    expect(access.resolveUrl(toStimulusFileUrl(shape))).toBe(
+      fs.realpathSync(shape)
+    );
+  });
+
+  it('does not write built-in directories to the persisted allowlist', () => {
+    authorizeBuiltInStimulusDirectories(access, root);
+
+    const reloaded = new StimulusFileAccess(path.join(root, 'authorized.json'));
+    const file = path.join(
+      root,
+      'experiments',
+      'faces_houses',
+      'stimuli',
+      'face.jpg'
+    );
+    fs.writeFileSync(file, 'image');
+    expect(() => reloaded.resolveUrl(toStimulusFileUrl(file))).toThrow(
+      'StimulusFileAccess.resolveUrl: file is not in an authorized directory'
     );
   });
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,7 +28,10 @@ import { lslOutlets } from './lsl/outlets';
 import { lslInlets } from './lsl/inlets';
 import { isLSLAvailable } from './lsl/native';
 import { persistExperimentState } from './workspaceState';
-import { StimulusFileAccess } from './stimulusFileAccess';
+import {
+  StimulusFileAccess,
+  authorizeBuiltInStimulusDirectories,
+} from './stimulusFileAccess';
 import {
   PYODIDE_SOURCE_DIR,
   PYODIDE_RESOURCE_DIR,
@@ -817,6 +820,18 @@ app.whenReady().then(async () => {
     const filePath = path.join(pyodideRoot, pathname);
     return net.fetch(pathToFileURL(filePath).href);
   });
+
+  // Built-in experiments ship their own stimuli under <resource>/experiments.
+  // They are loaded through the same bwfile:// scheme as custom/imported
+  // stimulus folders, so they must be on the allowlist. Add them implicitly
+  // (not persisted) because they are app assets, not user-selected folders.
+  const builtInResourcePath = is.dev
+    ? path.join(__dirname, '../../src/renderer')
+    : process.resourcesPath;
+  authorizeBuiltInStimulusDirectories(
+    getStimulusFileAccess(),
+    builtInResourcePath
+  );
 
   protocol.handle('bwfile', (request) => {
     const filePath = getStimulusFileAccess().resolveUrl(request.url);

--- a/src/main/stimulusFileAccess.ts
+++ b/src/main/stimulusFileAccess.ts
@@ -27,6 +27,23 @@ export class StimulusFileAccess {
     );
   }
 
+  /**
+   * Add a directory to the in-memory allowlist without persisting it.
+   *
+   * Use this for directories the app itself ships (e.g. built-in experiment
+   * stimuli), which should be reachable over bwfile:// but must not be written
+   * into the user-managed stimulus-directories.json file.
+   */
+  addImplicitDirectory(directory: string): void {
+    const canonical = fs.realpathSync(directory);
+    if (!fs.statSync(canonical).isDirectory()) {
+      throw new Error(
+        'StimulusFileAccess.addImplicitDirectory: expected a directory'
+      );
+    }
+    this.directories.add(canonical);
+  }
+
   resolveUrl(requestUrl: string): string {
     const url = new URL(requestUrl);
     const requestedPath = url.searchParams.get('path');
@@ -77,3 +94,30 @@ export class StimulusFileAccess {
     }
   }
 }
+
+/**
+ * Authorize every `<resourcePath>/experiments/<experiment>/stimuli` directory
+ * as an implicit (non-persisted) stimulus source.
+ *
+ * Built-in experiments ship their own stimuli and load them through the same
+ * bwfile:// scheme as custom/imported stimulus folders, so they must be on the
+ * allowlist. They are added implicitly because they are app assets, not
+ * user-selected folders.
+ */
+export const authorizeBuiltInStimulusDirectories = (
+  access: StimulusFileAccess,
+  resourcePath: string
+): void => {
+  const experimentsDir = path.join(resourcePath, 'experiments');
+  if (!fs.existsSync(experimentsDir)) return;
+
+  for (const entry of fs.readdirSync(experimentsDir, {
+    withFileTypes: true,
+  })) {
+    if (!entry.isDirectory()) continue;
+    const stimuliDir = path.join(experimentsDir, entry.name, 'stimuli');
+    if (fs.existsSync(stimuliDir) && fs.statSync(stimuliDir).isDirectory()) {
+      access.addImplicitDirectory(stimuliDir);
+    }
+  }
+};

--- a/src/renderer/components/AnalyzeComponent.tsx
+++ b/src/renderer/components/AnalyzeComponent.tsx
@@ -325,8 +325,8 @@ export default function Analyze(props: Props) {
   }
 
   function renderOverview() {
-    const { child: psdChild } = props.psdPlot;
-    const { child: topoChild } = props.topoPlot;
+    const psdSvg = props.psdPlot?.['image/svg+xml'];
+    const topoSvg = props.topoPlot?.['image/svg+xml'];
     return (
       <div className="p-4">
         <h1 className="mb-2">Overview</h1>
@@ -363,7 +363,7 @@ export default function Analyze(props: Props) {
           </div>
           <div>
             <h2>PSD Plot</h2>
-            {psdChild ? (
+            {psdSvg ? (
               <PyodidePlotWidget
                 title={props.title}
                 imageTitle="psd"
@@ -375,7 +375,7 @@ export default function Analyze(props: Props) {
           </div>
           <div>
             <h2>Topography</h2>
-            {topoChild ? (
+            {topoSvg ? (
               <PyodidePlotWidget
                 title={props.title}
                 imageTitle="topo"
@@ -391,11 +391,12 @@ export default function Analyze(props: Props) {
   }
 
   function renderERP() {
+    const erpSvg = props.erpPlot?.['image/svg+xml'];
     return (
       <div className="flex h-full">
         <div className="flex-1 p-4">
           <h1 className="mb-4">ERP</h1>
-          {props.erpPlot.child ? (
+          {erpSvg ? (
             <PyodidePlotWidget
               title={props.title}
               imageTitle="erp"

--- a/src/renderer/epics/pyodideEpics.ts
+++ b/src/renderer/epics/pyodideEpics.ts
@@ -222,7 +222,8 @@ const loadCleanedEpochsEpic: Epic<
       of(
         PyodideActions.GetEpochsInfo(PYODIDE_VARIABLE_NAMES.CLEAN_EPOCHS),
         PyodideActions.GetChannelInfo(),
-        PyodideActions.LoadTopo()
+        PyodideActions.LoadTopo(),
+        PyodideActions.LoadPSD()
       )
     )
   );

--- a/src/renderer/experiments/multitasking/__tests__/assets.test.ts
+++ b/src/renderer/experiments/multitasking/__tests__/assets.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { multitaskingExperimentObject } from '../experiment';
+
+type InstructionScreen = {
+  type: string;
+  files: Record<string, string>;
+  media: { images: string[] };
+};
+
+describe('multitasking experiment assets', () => {
+  const instructionScreen = multitaskingExperimentObject.content[0]
+    .content[1] as InstructionScreen;
+
+  it('routes instruction images through bwfile:// so lab.js can decode them', () => {
+    expect(instructionScreen.type).toBe('lab.html.Screen');
+    const { images: imageUrls } = instructionScreen.media;
+    expect(imageUrls.length).toBeGreaterThan(0);
+    for (const url of imageUrls) {
+      expect(url).toMatch(/^bwfile:\/\/host\?path=/);
+    }
+  });
+
+  it('maps each files entry to a bwfile:// URL', () => {
+    const { files } = instructionScreen;
+    const urls = Object.values(files);
+    expect(urls.length).toBeGreaterThan(0);
+    for (const url of urls) {
+      expect(url).toMatch(/^bwfile:\/\/host\?path=/);
+    }
+  });
+});

--- a/src/renderer/experiments/multitasking/experiment.ts
+++ b/src/renderer/experiments/multitasking/experiment.ts
@@ -1,5 +1,6 @@
 import path from 'pathe';
 import { RESOURCE_PATH } from '../../constants/constants';
+import { toStimulusFileUrl } from '../../../shared/stimulusUrl';
 import {
   initMultitaskingResponseHandlers,
   initTasks,
@@ -13,6 +14,9 @@ const assetsDirectory = path.join(
   'multitasking',
   'stimuli'
 );
+
+const assetUrl = (filename: string) =>
+  toStimulusFileUrl(path.join(assetsDirectory, filename));
 
 // Define study
 export const multitaskingExperimentObject = {
@@ -47,40 +51,31 @@ export const multitaskingExperimentObject = {
         {
           type: 'lab.html.Screen',
           files: {
-            'diamond_2.png': `${path.join(assetsDirectory, 'diamond_2.png')}`,
-            'diamond_3.png': `${path.join(assetsDirectory, 'diamond_3.png')}`,
-            'rectangle_2.png': `${path.join(
-              assetsDirectory,
-              'rectangle_2.png'
-            )}`,
-            'rectangle_3.png': `${path.join(
-              assetsDirectory,
-              'rectangle_3.png'
-            )}`,
-            'filling.png': `${path.join(assetsDirectory, 'filling.png')}`,
-            'shape.png': `${path.join(assetsDirectory, 'shape.png')}`,
-            'example_1.png': `${path.join(assetsDirectory, 'example_1.png')}`,
-            'example_2.png': `${path.join(assetsDirectory, 'example_2.png')}`,
-            'example_3.png': `${path.join(assetsDirectory, 'example_3.png')}`,
-            'example_4.png': `${path.join(assetsDirectory, 'example_4.png')}`,
-            'all_conditions.png': `${path.join(
-              assetsDirectory,
-              'all_conditions.png'
-            )}`,
+            'diamond_2.png': assetUrl('diamond_2.png'),
+            'diamond_3.png': assetUrl('diamond_3.png'),
+            'rectangle_2.png': assetUrl('rectangle_2.png'),
+            'rectangle_3.png': assetUrl('rectangle_3.png'),
+            'filling.png': assetUrl('filling.png'),
+            'shape.png': assetUrl('shape.png'),
+            'example_1.png': assetUrl('example_1.png'),
+            'example_2.png': assetUrl('example_2.png'),
+            'example_3.png': assetUrl('example_3.png'),
+            'example_4.png': assetUrl('example_4.png'),
+            'all_conditions.png': assetUrl('all_conditions.png'),
           },
           media: {
             images: [
-              `${path.join(assetsDirectory, 'diamond_2.png')}`,
-              `${path.join(assetsDirectory, 'diamond_3.png')}`,
-              `${path.join(assetsDirectory, 'rectangle_2.png')}`,
-              `${path.join(assetsDirectory, 'rectangle_3.png')}`,
-              `${path.join(assetsDirectory, 'filling.png')}`,
-              `${path.join(assetsDirectory, 'shape.png')}`,
-              `${path.join(assetsDirectory, 'example_1.png')}`,
-              `${path.join(assetsDirectory, 'example_2.png')}`,
-              `${path.join(assetsDirectory, 'example_3.png')}`,
-              `${path.join(assetsDirectory, 'example_4.png')}`,
-              `${path.join(assetsDirectory, 'all_conditions.png')}`,
+              assetUrl('diamond_2.png'),
+              assetUrl('diamond_3.png'),
+              assetUrl('rectangle_2.png'),
+              assetUrl('rectangle_3.png'),
+              assetUrl('filling.png'),
+              assetUrl('shape.png'),
+              assetUrl('example_1.png'),
+              assetUrl('example_2.png'),
+              assetUrl('example_3.png'),
+              assetUrl('example_4.png'),
+              assetUrl('all_conditions.png'),
             ],
           },
           parameters: {},


### PR DESCRIPTION
## Summary

Fixes three related issues discovered while running built-in experiments:

1. **Built-in stimuli authorization** — `bwfile://` requests for built-in experiment images (Faces/Houses, etc.) were rejected because only user-selected stimulus folders were added to `StimulusFileAccess`. Now `<resource>/experiments/*/stimuli` directories are authorized implicitly at startup.

2. **Analyze plots not rendering** — TOPO/PSD/ERP SVGs returned by the Pyodide worker were stored in Redux as `{ 'image/svg+xml': svg }` MIME bundles, but `AnalyzeComponent` was checking a non-existent `.child` property. It now checks for the actual SVG string. Also dispatches `LoadPSD` after `LoadCleanedEpochs`.

3. **Multi-tasking image decode failure** — The experiment used raw filesystem paths in its lab.js `files`/`media` entries, causing `EncodingError: The source image cannot be decoded`. Multi-tasking images now use `bwfile://` URLs, consistent with other built-in experiments.

## Verification

- `npm run typecheck` passes
- `node tests/electron-smoke.mjs` passes
- `npx vitest run src/renderer/experiments/multitasking/__tests__/assets.test.ts` passes
- `npx vitest run src/main/__tests__/stimulusFileAccess.test.ts` passes
